### PR TITLE
Add support for include-base64 config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,15 +1,26 @@
 options:
+  credentials:
+    description: |
+      The base64-encoded contents of an AWS credentials file, which must include
+      both 'aws_access_key_id' and 'aws_secret_access_key' fields.
+
+      This can be used from bundles with 'include-base64://' (see
+      https://jujucharms.com/docs/stable/charms-bundles#setting-charm-configurations-options-in-a-bundle),
+      or from the command-line with 'juju config aws credentials="$(base64 /path/to/file)"'.
+
+      It is strongly recommended that you use 'juju trust' instead, if available.
+      This will take precedence over the 'access-key' / 'secret-key' config options.
   access-key:
     description: |
       An IAM access key.
 
-      It is strongly recommended that you use `juju trust` instead, if available.
+      It is strongly recommended that you use 'juju trust' instead, if available.
     type: string
     default: ""
   secret-key:
     description: |
       An IAM secret key.
 
-      It is strongly recommended that you use `juju trust` instead, if available.
+      It is strongly recommended that you use 'juju trust' instead, if available.
     type: string
     default: ""

--- a/reactive/aws.py
+++ b/reactive/aws.py
@@ -10,7 +10,8 @@ from charms.reactive import (
 from charms import layer
 
 
-@when_any('config.changed.access-key',
+@when_any('config.changed.credentials',
+          'config.changed.access-key',
           'config.changed.secret-key')
 def update_creds():
     clear_flag('charm.aws.creds.set')


### PR DESCRIPTION
It's nicer to use `include-base64://` in a bundle overlay than providing the config values separately.

This includes changes from #11 so PR'd against that branch instead of master.