### PR TITLE
Handle subnet ID query failure and other AWS errors better

### DIFF
--- a/lib/charms/layer/aws.py
+++ b/lib/charms/layer/aws.py
@@ -152,6 +152,10 @@ def tag_instance_subnet(instance_id, region, tags):
                      '--query', 'Reservations[*]'
                                 '.Instances[*]'
                                 '.SubnetId[] | [0]')
+    if subnet_id is None:
+        raise AWSError(None, ('Unable to determine subnet ID for {}; '
+                              'do the credentials have sufficient rights?'
+                              ''.format(instance_id)))
     _apply_tags(region, [subnet_id], tags)
 
 


### PR DESCRIPTION
To at least improve the user experience when failures such as #23 occur, this explicitly catches subnet ID query failures and handles all errors interacting with AWS a bit more gracefully.