### PR TITLE
Add support for ELB service-linked role

### DIFF
--- a/files/policies/elb.json
+++ b/files/policies/elb.json
@@ -9,7 +9,16 @@
     {
       "Effect": "Allow",
       "Action": [ "iam:CreateServiceLinkedRole" ],
-      "Resource": [ "arn:aws:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/*" ]
+      "Resource": [ "arn:aws:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/*" ],
+      "Condition": {"StringLike": {"iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"}}
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:AttachRolePolicy",
+        "iam:PutRolePolicy"
+      ],
+      "Resource": "arn:aws:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/*"
     }
   ]
 }

--- a/files/policies/elb.json
+++ b/files/policies/elb.json
@@ -5,6 +5,11 @@
       "Effect": "Allow",
       "Action": [ "elasticloadbalancing:*" ],
       "Resource": [ "*" ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [ "iam:CreateServiceLinkedRole" ],
+      "Resource": [ "arn:aws:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/*" ]
     }
   ]
 }


### PR DESCRIPTION
Fix k8s integration errors like:

```
Error creating load balancer (will retry): failed to ensure load balancer for service jupyterhub/proxy-public: AccessDenied: User: arn:aws:sts::040341551200:assumed-role/charm.aws.cee1b054-cd94-4196-8d07-f3979872b6ff.kubernetes-master/i-0fffffffffffffff is not authorized to perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::0000000000:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing 
```