### PR TITLE
Add automatic and manual cleanup for subnet tags

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -31,3 +31,50 @@ update-policies:
   description: |
     Check for new policy definitions and update as needed.  Note: This is done
     automatically on charm upgrade.
+list-subnet-tags:
+  description: |
+    Return a mapping of subnet IDs to a comma-separated list of tags for all
+    subnets in the current or specified region.
+  params:
+    region:
+      description: |
+        Region in which to act.  If not specified, uses the region that
+        this application is deployed into.
+      type: string
+      default: ''
+purge-subnet-tags:
+  description: |
+    Purge tags on all subnets in the current or specified region, optionally
+    filtering or excluding by patterns or subnets.  Returns a mapping of
+    subnet IDs to the tags removed from them.
+  params:
+    region:
+      description: |
+        Region in which to act.  If not specified, uses the region that
+        this application is deployed into.
+      type: string
+      default: ''
+    subnet-ids:
+      description: |
+        Comma-separate list of IDs of subnets from which to remove tags.  If
+        not given, tags from any subnet will be processed.
+      type: string
+      default: ''
+    include:
+      description: |
+        Regular expression pattern to filter tag keys by.  If not given, will
+        match all tags.
+      type: string
+      default: ''
+    exclude:
+      description: |
+        Regular expression pattern to exclude tag keys by.  If not given, will
+        match all tags.  Can be used with the exclude param to exclude tags
+        which would otherwise be included.
+      type: string
+      default: ''
+    dry-run:
+      description: |
+        Report what would be purged without actually removing anything.
+      type: boolean
+      default: false

--- a/actions.yaml
+++ b/actions.yaml
@@ -63,14 +63,13 @@ purge-subnet-tags:
     include:
       description: |
         Regular expression pattern to filter tag keys by.  If not given, will
-        match all tags.
+        include all tags.
       type: string
       default: ''
     exclude:
       description: |
         Regular expression pattern to exclude tag keys by.  If not given, will
-        match all tags.  Can be used with the subnet-ids and include params to
-        exclude tags which would otherwise be included.
+        not exclude any tags.
       type: string
       default: ''
     dry-run:

--- a/actions.yaml
+++ b/actions.yaml
@@ -62,13 +62,13 @@ purge-subnet-tags:
       default: ''
     include:
       description: |
-        Regular expression pattern to filter tag keys by.  If not given, will
+        Regular expression pattern to filter tags by key.  If not given, will
         include all tags.
       type: string
       default: ''
     exclude:
       description: |
-        Regular expression pattern to exclude tag keys by.  If not given, will
+        Regular expression pattern to exclude tags by key.  If not given, will
         not exclude any tags.
       type: string
       default: ''

--- a/actions.yaml
+++ b/actions.yaml
@@ -69,8 +69,8 @@ purge-subnet-tags:
     exclude:
       description: |
         Regular expression pattern to exclude tag keys by.  If not given, will
-        match all tags.  Can be used with the exclude param to exclude tags
-        which would otherwise be included.
+        match all tags.  Can be used with the subnet-ids and include params to
+        exclude tags which would otherwise be included.
       type: string
       default: ''
     dry-run:

--- a/actions/list-subnet-tags
+++ b/actions/list-subnet-tags
@@ -1,0 +1,26 @@
+#!/usr/local/sbin/charm-env python3
+
+import os
+import string
+
+from charmhelpers.core import hookenv
+from charms import layer
+from reactive import snap
+
+
+layer.import_layer_libs()
+
+JUJU_AZ = os.environ['JUJU_AVAILABILITY_ZONE']
+JUJU_REGION = JUJU_AZ.rstrip(string.ascii_lowercase)
+
+
+try:
+    # ensure /snap/bin is on the path
+    snap.ensure_path()
+
+    region = hookenv.action_get('region') or JUJU_REGION
+    subnet_tags = layer.aws._list_subnet_tags(region)
+    hookenv.action_set({'tags.{}'.format(k): ', '.join(v)
+                        for k, v in subnet_tags.items()})
+except layer.aws.AWSError as e:
+    hookenv.action_fail(e.message)

--- a/actions/purge-subnet-tags
+++ b/actions/purge-subnet-tags
@@ -1,0 +1,55 @@
+#!/usr/local/sbin/charm-env python3
+
+import re
+import os
+import string
+
+from charmhelpers.core import hookenv
+from charms import layer
+from reactive import snap
+
+
+layer.import_layer_libs()
+
+
+CSV_PAT = re.compile(r'\s*,\s*')
+ALL_PAT = re.compile(r'.*')  # always matches
+NONE_PAT = re.compile(r'(?!)')  # never matches
+
+JUJU_AZ = os.environ['JUJU_AVAILABILITY_ZONE']
+JUJU_REGION = JUJU_AZ.rstrip(string.ascii_lowercase)
+
+
+try:
+    # ensure /snap/bin is on the path
+    snap.ensure_path()
+
+    region = hookenv.action_get('region') or JUJU_REGION
+    subnet_ids = hookenv.action_get('subnet-ids')
+    include = re.compile(hookenv.action_get('include') or ALL_PAT)
+    exclude = re.compile(hookenv.action_get('exclude') or NONE_PAT)
+    dry_run = hookenv.action_get('dry-run')
+    subnet_tags = layer.aws._list_subnet_tags(region)
+    removed_tags = {}
+    if subnet_ids:
+        subnet_ids = CSV_PAT.split(subnet_ids)
+    else:
+        subnet_ids = subnet_tags.keys()
+    for subnet_id in subnet_ids:
+        tags = subnet_tags[subnet_id]
+        tags = [tag for tag in tags if include.search(tag)]
+        tags = [tag for tag in tags if not exclude.search(tag)]
+        if not tags:
+            continue
+        if not dry_run:
+            layer.aws._cleanup_subnet_tags(region, subnet_id, tags)
+        removed_tags[subnet_id] = tags
+        hookenv.log('Tags {}removed from subnet {}: {}'.format(
+            'would be ' if dry_run else '',
+            subnet_id,
+            ', '.join(tags)), hookenv.DEBUG)
+    hookenv.action_set({'tags.{}'.format(k): ', '.join(v)
+                        for k, v in removed_tags.items()})
+    hookenv.action_set({'removed': not dry_run})
+except layer.aws.AWSError as e:
+    hookenv.action_fail(e.message)

--- a/lib/charms/layer/aws.py
+++ b/lib/charms/layer/aws.py
@@ -524,6 +524,14 @@ def _list_policies(model_uuid=None):
                                         model_uuid=model_uuid))
 
 
+def _list_subnet_tags(region):
+    results = _aws('ec2', 'describe-subnets',
+                   '--region', region,
+                   '--query', 'Subnets[*].[SubnetId,Tags]')
+    return {subnet_id: [tag['Key'] for tag in tags]
+            for subnet_id, tags in results if tags}
+
+
 def _get_managed_entities():
     """
     Get the set of IAM entities managed by this charm instance.

--- a/lib/charms/layer/aws.py
+++ b/lib/charms/layer/aws.py
@@ -4,6 +4,7 @@ import re
 import sys
 import subprocess
 from base64 import b64decode
+from collections import defaultdict
 from math import ceil, floor
 from time import sleep
 from configparser import ConfigParser, MissingSectionHeaderError
@@ -141,7 +142,7 @@ def tag_instance_security_group(instance_id, region, tags):
     _apply_tags(region, [group_id], tags)
 
 
-def tag_instance_subnet(instance_id, region, tags):
+def tag_instance_subnet(application_name, instance_id, region, tags):
     """
     Tag the subnet for the given instance with the given tags.
 
@@ -158,6 +159,9 @@ def tag_instance_subnet(instance_id, region, tags):
                                 '.SubnetId[] | [0]')
     if subnet_id is not None:
         _apply_tags(region, [subnet_id], tags)
+        _add_app_entity(application_name,
+                        'subnet-tags',
+                        ((region, subnet_id), list(tags.keys())))
     else:
         log('Unable to determine subnet ID for {}; possibly EC2-Classic',
             instance_id)
@@ -371,7 +375,8 @@ def cleanup(current_applications):
     departed_applications = managed_entities.keys() - current_applications
     if not departed_applications:
         return
-    log('Cleaning up unused AWS entities')
+    log('Cleaning up {} AWS entities',
+        'unused' if current_applications else 'all')
     for app in departed_applications:
         entities = managed_entities.pop(app)
         for role in entities['role']:
@@ -380,6 +385,12 @@ def cleanup(current_applications):
             _cleanup_instance_profile(instance_profile)
         for policy in entities['policy']:
             _cleanup_policy(policy)
+        # group subnet tags by region / subnet-id pair
+        subnet_tags = defaultdict(list)
+        for (region, subnet_id), tags in entities['subnet-tags']:
+            subnet_tags[(region, subnet_id)].extend(tags)
+        for (region, subnet_id), tags in subnet_tags.items():
+            _cleanup_subnet_tags(region, subnet_id, tags)
     _set_managed_entities(managed_entities)
 
 
@@ -529,6 +540,7 @@ def _add_app_entity(app_name, entity_type, entity_name):
         'role': [],
         'instance-profile': [],
         'policy': [],
+        'subnet-tags': [],
     })
     if entity_name not in app_entities[entity_type]:
         app_entities[entity_type].append(entity_name)
@@ -853,5 +865,19 @@ def _cleanup_policy(policy_arn):
             if policy_file.exists():
                 policy_file.unlink()
         log('Deleted IAM policy {}', policy_arn)
+    except DoesNotExistAWSError:
+        pass
+
+
+def _cleanup_subnet_tags(region, subnet_id, tags):
+    """
+    Cleanup an IAM instance-profile.
+    """
+    try:
+        _aws(*(['ec2', 'delete-tags'] +
+               ['--region', region] +
+               ['--resources', subnet_id] +
+               ['--tags'] + ['Key={}'.format(tag) for tag in tags]))
+        log('Deleted tags from subnet {}: {}', subnet_id, ','.join(tags))
     except DoesNotExistAWSError:
         pass

--- a/reactive/aws.py
+++ b/reactive/aws.py
@@ -72,6 +72,7 @@ def handle_requests():
                     request.instance_security_group_tags)
             if request.instance_subnet_tags:
                 layer.aws.tag_instance_subnet(
+                    request.application_name,
                     request.instance_id,
                     request.region,
                     request.instance_subnet_tags)
@@ -139,3 +140,13 @@ def upgrade_charm():
         hookenv.log(format_exc(), hookenv.ERROR)
         layer.status.blocked('error while updating policies; '
                              'check credentials and debug-log')
+
+
+@hook('stop')
+def final_cleanup():
+    try:
+        # cleanup all managed entities, including
+        # ones we might have missed previously
+        layer.aws.cleanup([])
+    except layer.aws.AWSError:
+        pass  # can't stop the stop


### PR DESCRIPTION
Because subnets live as long as the VPC they're attached to and most people reuse a single default VPC, cluster tags on the subnets can end up reaching the relatively low 50 tag limit.

This PR adds automatic removal of tags requested by related applications during cleanup.  However, since destroying a model (typical for getting rid of a cluster) doesn't usually give the charm enough of a chance to perform a clean shutdown, tags will often get missed (this is the same issue we have with IAM entities, which are also attempted to be cleaned up but require manual intervention from time to time).  So this also adds a `list-subnet-tags` and a `purge-subnet-tags` action to facilitate manual cleanup.

Fixes [lp:1823106](https://bugs.launchpad.net/charm-aws-integrator/+bug/1823106) and [lp:1821785](https://bugs.launchpad.net/charm-aws-integrator/+bug/1821785)

Example usage and output from `purge-subnet-tags`:

```
$ juju run-action aws-integrator/0 purge-subnet-tags include='kubernetes.io/cluster'
unit-aws-integrator-0:
  id: 30ebe518-ed6c-47f3-82d1-b48122f3c8d1
  results:
    removed: "True"
    tags:
      subnet-5096f67c: kubernetes.io/cluster/kubernetes-nrxtgdbwm7ug4zrisxwxijabkc2qan0l
      subnet-cda9f385: kubernetes.io/cluster/kubernetes-nrxtgdbwm7ug4zrisxwxijabkc2qan0l
  status: completed
  timing:
    completed: 2019-04-08 19:33:24 +0000 UTC
    enqueued: 2019-04-08 19:33:14 +0000 UTC
    started: 2019-04-08 19:33:18 +0000 UTC
  unit: aws-integrator/0
```