### PR TITLE
use extended interface-aws-integration to apply more aws policies

### DIFF
--- a/files/policies/autoscaling-readonly.json
+++ b/files/policies/autoscaling-readonly.json
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeTags"
+      ],
+      "Resource": "*"
+    }]
+  }
+  

--- a/files/policies/ebs.json
+++ b/files/policies/ebs.json
@@ -18,6 +18,11 @@
     },
     {
       "Effect": "Allow",
+      "Action": "ec2:ModifyVolume",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
       "Action": "ec2:DetachVolume",
       "Resource": "*"
     },

--- a/files/policies/instance-modification.json
+++ b/files/policies/instance-modification.json
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "ec2:ModifyInstanceAttribute",
+        "Resource": [ "*" ]
+      }
+    ]
+  }
+  

--- a/files/policies/network-management.json
+++ b/files/policies/network-management.json
@@ -11,6 +11,8 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
+        "ec2:DeleteRoute",
         "ec2:DeleteSecurityGroup",
         "ec2:RevokeSecurityGroupIngress"
       ],

--- a/files/policies/region-readonly.json
+++ b/files/policies/region-readonly.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+            "ec2:DescribeRegions",
+            "ec2:DescribeAvailabilityZones"
+        ],
+        "Resource": [
+          "*"
+        ]
+      }
+    ]
+}
+  

--- a/reactive/aws.py
+++ b/reactive/aws.py
@@ -87,7 +87,15 @@ def handle_requests():
                 layer.aws.enable_acm_fullaccess(
                     request.application_name, request.instance_id, request.region
                 )
+            if request.requested_autoscaling_readonly:
+                layer.aws.enable_autoscaling_readonly(
+                    request.application_name, request.instance_id, request.region
+                )
             if request.requested_instance_inspection:
+                layer.aws.enable_instance_inspection(
+                    request.application_name, request.instance_id, request.region
+                )
+            if request.requested_instance_modification:
                 layer.aws.enable_instance_inspection(
                     request.application_name, request.instance_id, request.region
                 )
@@ -105,6 +113,10 @@ def handle_requests():
                 )
             if request.requested_dns_management:
                 layer.aws.enable_dns_management(
+                    request.application_name, request.instance_id, request.region
+                )
+            if request.requested_region_readonly:
+                layer.aws.enable_region_readonly(
                     request.application_name, request.instance_id, request.region
                 )
             if request.requested_object_storage_access:

--- a/reactive/aws.py
+++ b/reactive/aws.py
@@ -96,7 +96,7 @@ def handle_requests():
                     request.application_name, request.instance_id, request.region
                 )
             if request.requested_instance_modification:
-                layer.aws.enable_instance_inspection(
+                layer.aws.enable_instance_modification(
                     request.application_name, request.instance_id, request.region
                 )
             if request.requested_network_management:


### PR DESCRIPTION
[LP#2013090](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2013090)

condenses `charms.layers.aws` methods:

* `enable_acm_readonly`
* `enable_acm_fullaccess`
* `enable_block_storage_management`
* `enable_load_balancer_management`
* `enable_instance_inspection`
* `enable_network_management`
* `enable_dns_management`
* `enable_object_storage_access`
* `enable_object_storage_management`

down into a single partial method

adding
* `enable_autoscaling_readonly`
* `enable_instance_modification`
* `enable_region_readonly`

These new methods enable the k8s-control-plane charm to request features necessary to satisfy the [prerequisites](https://github.com/kubernetes/cloud-provider-aws/blob/master/docs/prerequisites.md)



Call the new methods by way of changes to [`interface-aws-integration`](https://github.com/juju-solutions/interface-aws-integration/pull/15)
* https://github.com/juju-solutions/interface-aws-integration/pull/15