### PR TITLE
[LP#2033082] Use `yaml.safe_load` over `yaml.load`

### DIFF
--- a/lib/charms/layer/aws.py
+++ b/lib/charms/layer/aws.py
@@ -58,7 +58,7 @@ def get_credentials():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        creds = yaml.load(result.stdout.decode("utf8"))
+        creds = yaml.safe_load(result.stdout.decode("utf8"))
         access_key = creds["credential"]["attributes"]["access-key"]
         secret_key = creds["credential"]["attributes"]["secret-key"]
         update_credentials_file(access_key, secret_key)


### PR DESCRIPTION
PYyaml 6.0 finally drops `yaml.load` without a `Loader`.  Switching to `safe_load` instead